### PR TITLE
Fix rewind bugs (overlay doesn't hide)

### DIFF
--- a/lib/videojs-overlay.js
+++ b/lib/videojs-overlay.js
@@ -101,8 +101,8 @@
           }
         },
         // returns a listener function that executes a callback when
-        // the specified property of one of the overlays is less than
-        // the current playback time
+        // the specified property of one of the overlays is positive
+        // comapred with the current playback time (compareFunction == true)
         addTimeupdateListener = function(overlays, prop, callback, compareFunction) {
           var lastTime = 0,
               earliest = 0,

--- a/lib/videojs-overlay.js
+++ b/lib/videojs-overlay.js
@@ -53,8 +53,10 @@
     player.el().appendChild(el);
   };
   hideOverlay = function(player, settings, overlay) {
-    overlay.el.parentNode.removeChild(overlay.el);
-    delete overlay.el;
+    if (overlay.el) {
+      overlay.el.parentNode.removeChild(overlay.el);
+      delete overlay.el;
+    }
   };
 
   /**
@@ -191,11 +193,7 @@
     // setup time-based overlay ends
     if (endTimes.length) {
       endTimes.sort(ascendingByEnd);
-      addTimeupdateListener(endTimes, 'end', function(player, settings, overlay) {
-        if (overlay.el) {
-          hideOverlay(player, settings, overlay);
-        }
-      });
+      addTimeupdateListener(endTimes, 'end', hideOverlay);
     }
   };
 

--- a/lib/videojs-overlay.js
+++ b/lib/videojs-overlay.js
@@ -103,7 +103,7 @@
         // returns a listener function that executes a callback when
         // the specified property of one of the overlays is less than
         // the current playback time
-        addTimeupdateListener = function(overlays, prop, callback) {
+        addTimeupdateListener = function(overlays, prop, callback, compareFunction) {
           var lastTime = 0,
               earliest = 0,
               listener;
@@ -119,7 +119,7 @@
               overlay = overlays[earliest];
             }
 
-            for (; overlay && overlay[prop] <= time;
+            for (; overlay && compareFunction(overlay[prop], time);
                  overlay = overlays[++earliest]) {
               callback(player, settings, overlay);
             }
@@ -187,13 +187,20 @@
     // setup time-based overlay starts
     if (startTimes.length) {
       startTimes.sort(ascendingByStart);
-      addTimeupdateListener(startTimes, 'start', showOverlay);
+      addTimeupdateListener(startTimes, 'start', showOverlay, function(prop, time) {
+        return prop <= time;
+      });
+      addTimeupdateListener(startTimes, 'start', hideOverlay, function(prop, time) {
+        return prop > time;
+      });
     }
 
     // setup time-based overlay ends
     if (endTimes.length) {
       endTimes.sort(ascendingByEnd);
-      addTimeupdateListener(endTimes, 'end', hideOverlay);
+      addTimeupdateListener(endTimes, 'end', hideOverlay, function(prop, time) {
+        return prop <= time;
+      });
     }
   };
 

--- a/test/videojs-overlay.test.js
+++ b/test/videojs-overlay.test.js
@@ -424,4 +424,20 @@
     ok(player.el().querySelector('.vjs-overlay.vjs-overlay-bottom-right'),
        'applies left class');
   });
+
+  test('removes time based overlays if the user seeks backward', function() {
+    player.overlay({
+      overlays: [{
+        start: 5,
+        end: 10
+      }]
+    });
+
+    // display the overlay
+    updateTime(6);
+    ok(player.el().querySelector('.vjs-overlay'), 'shows the overlay');
+    // seek backward to before the overlay
+    updateTime(4);
+    ok(!player.el().querySelector('.vjs-overlay'), 'hides the overlay');
+  });
 })(window, window.videojs, window.QUnit);


### PR DESCRIPTION
Fixed: If you rewind backward when overlay is visible to time before overlay must be shown, then overlay doesn't hide and will be live forever.