### PR TITLE
Fixes the max-width styling causing backwards compatibility issues fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # CHANGELOG
 
 ## HEAD (Unreleased)
-_(none)_
+* Fixed issue where max-width was being set on all overlays rather than only those showBackground=false.
 
 --------------------
 
 ## 1.1.0 (2016-07-27)
-_(none)_
+* Added showBackground option to show or hide the overlay background.
+* Added attachToControlBar option to allow bottom align control bars to move when the control bar minimizes.
 
 ## 1.0.2 (2016-06-10)
 _(none)_
@@ -20,4 +21,3 @@ _(none)_
 
 ## 0.1.0 (2014-04-29)
 * Initial release
-

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -92,7 +92,7 @@ class Overlay extends Component {
     let options = this.options_;
     let content = options.content;
 
-    let background = options.showBackground ? 'vjs-overlay-background' : '';
+    let background = options.showBackground ? 'vjs-overlay-background' : 'vjs-overlay-no-background';
     let el = videojs.createEl('div', {
       className: `
         vjs-overlay

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -9,6 +9,9 @@
     color: #fff;
     position: absolute;
     text-align: center;
+  }
+  
+  .vjs-overlay-no-background {
     max-width: 33%;
   }
 


### PR DESCRIPTION
…r users that have overridden the width attribute on vjs-overlay.

Not setting a width when not using the background is useful for the overlay appearing properly aligned in the video in cases where the overlay is smaller than the width specified. If we used width: 33% with no background many overlays would appear to be floating more in the center of the video rather than aligned to the edge. However, we do need SOME width value or overlays will often overtake the video. So max-width is what is needed. However, even though the width is already set to 33% for the overlay with background, setting max-width in that situation interferes with any overlay that overrides that width value with custom css. To maintain backwards compatibility, I've moved around the style so max-width only applies when the showBackground setting is set to false.