### PR TITLE
Fix vertical centre alignment & add align-center

### DIFF
--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -79,6 +79,7 @@
   .vjs-no-flex .vjs-overlay-left,
   .vjs-no-flex .vjs-overlay-center,
   .vjs-no-flex .vjs-overlay-right {
-    top: $offset-h;
+    margin-top: $offset-v;
   }
 }
+

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -75,6 +75,7 @@
     transform: translateY(-50%);
   }
 
+  // Fallback for IE8 and IE9
   .vjs-no-flex .vjs-overlay-left,
   .vjs-no-flex .vjs-overlay-center,
   .vjs-no-flex .vjs-overlay-right {

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -10,7 +10,7 @@
     position: absolute;
     text-align: center;
   }
-  
+
   .vjs-overlay-no-background {
     max-width: 33%;
   }
@@ -41,9 +41,9 @@
   }
 
   .vjs-overlay-right {
-    margin-top: $offset-v;
     right: $nudge;
     top: $middle;
+    transform: translateY(-50%);
   }
 
   .vjs-overlay-bottom-right {
@@ -64,7 +64,20 @@
 
   .vjs-overlay-left {
     left: $nudge;
-    margin-top: $offset-v;
     top: $middle;
+    transform: translateY(-50%);
+  }
+
+  .vjs-overlay-center {
+    left: $middle;
+    margin-left: $offset-h;
+    top: $middle;
+    transform: translateY(-50%);
+  }
+
+  .vjs-no-flex .vjs-overlay-left,
+  .vjs-no-flex .vjs-overlay-center,
+  .vjs-no-flex .vjs-overlay-right {
+    top: $offset-h;
   }
 }


### PR DESCRIPTION
- Use `transform: translateY(-50%)` to better centre vertically
- Keep `margin-top: -15px` targetted to IE8/9 as fallback (`.vjs-no-flex`)
- Add `align-center` option