### PR TITLE
Video.js 5 and 6 cross-compatibility.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,6 +16,7 @@ const defaults = {
 };
 
 const Component = videojs.getComponent('Component');
+const registerPlugin = videojs.registerPlugin || videojs.plugin;
 
 /**
  * Whether the value is a `Number`.
@@ -93,7 +94,7 @@ class Overlay extends Component {
     let content = options.content;
 
     let background = options.showBackground ? 'vjs-overlay-background' : 'vjs-overlay-no-background';
-    let el = videojs.createEl('div', {
+    let el = videojs.dom.createEl('div', {
       className: `
         vjs-overlay
         vjs-overlay-${options.align}
@@ -108,7 +109,7 @@ class Overlay extends Component {
     } else if (content instanceof window.DocumentFragment) {
       el.appendChild(content);
     } else {
-      videojs.appendContent(el, content);
+      videojs.dom.appendContent(el, content);
     }
 
     return el;
@@ -342,6 +343,6 @@ const plugin = function(options) {
 
 plugin.VERSION = '__VERSION__';
 
-videojs.plugin('overlay', plugin);
+registerPlugin('overlay', plugin);
 
 export default plugin;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,6 +16,9 @@ const defaults = {
 };
 
 const Component = videojs.getComponent('Component');
+
+// These are for cross-compatibility between Video.js 5 and 6.
+const dom = videojs.dom || videojs;
 const registerPlugin = videojs.registerPlugin || videojs.plugin;
 
 /**
@@ -94,7 +97,7 @@ class Overlay extends Component {
     let content = options.content;
 
     let background = options.showBackground ? 'vjs-overlay-background' : 'vjs-overlay-no-background';
-    let el = videojs.dom.createEl('div', {
+    let el = dom.createEl('div', {
       className: `
         vjs-overlay
         vjs-overlay-${options.align}
@@ -109,7 +112,7 @@ class Overlay extends Component {
     } else if (content instanceof window.DocumentFragment) {
       el.appendChild(content);
     } else {
-      videojs.dom.appendContent(el, content);
+      dom.appendContent(el, content);
     }
 
     return el;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -8,6 +8,9 @@ import plugin from '../src/plugin';
 
 const Player = videojs.getComponent('Player');
 
+// This is for cross-compatibility between Video.js 5 and 6.
+const dom = videojs.dom || videojs;
+
 QUnit.test('the environment is sane', function(assert) {
   assert.strictEqual(typeof Array.isArray, 'function', 'es5 exists');
   assert.strictEqual(typeof sinon, 'object', 'sinon exists');
@@ -44,7 +47,7 @@ QUnit.module('videojs-overlay', {
     this.assertOverlayCount = (assert, expected) => {
       let overlays = Array.prototype.filter.call(
         this.player.$$('.vjs-overlay'),
-        el => !videojs.dom.hasClass(el, 'vjs-hidden')
+        el => !dom.hasClass(el, 'vjs-hidden')
       );
       let actual = overlays ? overlays.length : 0;
       let one = expected === 1;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -44,7 +44,7 @@ QUnit.module('videojs-overlay', {
     this.assertOverlayCount = (assert, expected) => {
       let overlays = Array.prototype.filter.call(
         this.player.$$('.vjs-overlay'),
-        el => !videojs.hasClass(el, 'vjs-hidden')
+        el => !videojs.dom.hasClass(el, 'vjs-hidden')
       );
       let actual = overlays ? overlays.length : 0;
       let one = expected === 1;
@@ -64,8 +64,8 @@ QUnit.test('registers itself with video.js', function(assert) {
   assert.expect(2);
 
   assert.strictEqual(
-    Player.prototype.overlay,
-    plugin,
+    typeof Player.prototype.overlay,
+    'function',
     'videojs-overlay plugin was registered'
   );
 


### PR DESCRIPTION
Most of this is to avoid deprecation warnings.