### PR TITLE
remove global browserify transforms, and call as needed instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,6 @@
     "videojs",
     "videojs-plugin"
   ],
-  "browserify": {
-    "transform": [
-      "browserify-shim",
-      "browserify-versionify"
-    ]
-  },
   "browserify-shim": {
     "qunit": "global:QUnit",
     "sinon": "global:sinon",
@@ -38,7 +32,7 @@
     "build:js": "npm-run-all build:js:babel build:js:browserify build:js:bannerize build:js:uglify",
     "build:js:babel": "babel src -d es5",
     "build:js:bannerize": "bannerize dist/videojs-overlay.js --banner=scripts/banner.ejs",
-    "build:js:browserify": "browserify . -s videojs-overlay -o dist/videojs-overlay.js",
+    "build:js:browserify": "browserify . -s videojs-overlay -g browserify-shim -t browserify-versionify -o dist/videojs-overlay.js",
     "build:js:uglify": "uglifyjs dist/videojs-overlay.js --comments --mangle --compress -o dist/videojs-overlay.min.js",
     "build:test": "babel-node scripts/build-test.js",
     "build:test:browserify": "browserify `find test -name '*.test.js'` -t babelify -o dist-test/videojs-overlay.js",

--- a/scripts/build-test.js
+++ b/scripts/build-test.js
@@ -10,6 +10,8 @@ glob('test/**/*.test.js', (err, files) => {
   }
   browserify(files)
     .transform('babelify')
+    .transform('browserify-shim', {global: true})
+    .transform('browserify-versionify')
     .bundle()
     .pipe(fs.createWriteStream('test/dist/bundle.js'));
 });

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -35,7 +35,7 @@ const bundlers = {
     standalone: nameify('%s'),
     transform: [
       'babelify',
-      'browserify-shim',
+      ['browserify-shim', {global: true}],
       'browserify-versionify'
     ]
   }),
@@ -45,7 +45,7 @@ const bundlers = {
     entries: srces.tests,
     transform: [
       'babelify',
-      'browserify-shim',
+      ['browserify-shim', {global: true}],
       'browserify-versionify'
     ]
   })


### PR DESCRIPTION
This fixes instances where this package will be used as a dependency in projects that use browserify on it.