### PR TITLE
feat: Choose placement of overlay elements in controlBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ _This setting can be overridden by being set on individual overlay objects._
 
 If set to true, bottom aligned overlays will adjust positioning when the control bar minimizes. This has no effect on overlays that are not aligned to bottom, bottom-left, or bottom-right. For use with the default control bar, it may not work for custom control bars.
 
+#### `insertBefore`
+
+__Type:__ `String`
+__Default:__ `""`
+
+_This setting can be overridden by being set on individual overlay objects._
+
+The `string` name of a ControlBar component. Requires `attachToControlBar` set to `true`.
+
+Overlays set to align `"bottom-right"`, `"bottom"`, or `"bottom-left"` are inserted before the chosen component. These bottom overlays are otherwise inserted before the first child component of the ControlBar while overlays using other alignments are inserted before the ControlBar component.
+
 #### `class`
 
 __Type:__ `String`

--- a/README.md
+++ b/README.md
@@ -46,23 +46,16 @@ Whether or not to include background styling & padding around the overlay.
 
 #### `attachToControlBar`
 
-__Type:__ `Boolean`
+__Type:__ `Boolean`, `String`
 __Default:__ `false`
 
 _This setting can be overridden by being set on individual overlay objects._
 
-If set to true, bottom aligned overlays will adjust positioning when the control bar minimizes. This has no effect on overlays that are not aligned to bottom, bottom-left, or bottom-right. For use with the default control bar, it may not work for custom control bars.
+If set to `true` or a `string` value, bottom aligned overlays will adjust positioning when the control bar minimizes. This has no effect on overlays that are not aligned to bottom, bottom-left, or bottom-right. For use with the default control bar, it may not work for custom control bars.
 
-#### `insertBefore`
+The value of `string` must be the name of a ControlBar component.
 
-__Type:__ `String`
-__Default:__ `""`
-
-_This setting can be overridden by being set on individual overlay objects._
-
-The `string` name of a ControlBar component. Requires `attachToControlBar` set to `true`.
-
-Overlays set to align `"bottom-right"`, `"bottom"`, or `"bottom-left"` are inserted before the chosen component. These bottom overlays are otherwise inserted before the first child component of the ControlBar while overlays using other alignments are inserted before the ControlBar component.
+Bottom aligned overlays will be inserted before the specified component. Otherwise, bottom aligned overlays are inserted before the first child component of the ControlBar. All other overlays are inserted before the ControlBar component.
 
 #### `class`
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "npm-run-all": "^4.0.2",
     "qunitjs": "^2.3.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.41.6",
+    "rollup": "^0.51.8",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.1.1",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,7 +8,6 @@ const defaults = {
   debug: false,
   showBackground: true,
   attachToControlBar: false,
-  insertBefore: '',
   overlays: [{
     start: 'playing',
     end: 'paused'
@@ -322,13 +321,18 @@ const plugin = function(options) {
 
   this.overlays_ = overlays.map(o => {
     const mergeOptions = videojs.mergeOptions(settings, o);
+    const attachToControlBar = typeof mergeOptions.attachToControlBar === 'string' || mergeOptions.attachToControlBar === true;
 
     if (!this.controls() || !this.controlBar) {
       return this.addChild('overlay', mergeOptions);
     }
 
-    if (mergeOptions.attachToControlBar && mergeOptions.align.indexOf('bottom') !== -1) {
-      const referenceChild = this.controlBar.getChild(mergeOptions.insertBefore) || this.controlBar.children()[0];
+    if (attachToControlBar && mergeOptions.align.indexOf('bottom') !== -1) {
+      let referenceChild = this.controlBar.children()[0];
+
+      if (this.controlBar.getChild(mergeOptions.attachToControlBar) !== undefined) {
+        referenceChild = this.controlBar.getChild(mergeOptions.attachToControlBar);
+      }
 
       if (referenceChild) {
         const controlBarChild = this.controlBar.addChild('overlay', mergeOptions);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,6 +8,7 @@ const defaults = {
   debug: false,
   showBackground: true,
   attachToControlBar: false,
+  insertBefore: '',
   overlays: [{
     start: 'playing',
     end: 'paused'
@@ -322,15 +323,31 @@ const plugin = function(options) {
   this.overlays_ = overlays.map(o => {
     const mergeOptions = videojs.mergeOptions(settings, o);
 
-    // Attach bottom aligned overlays to the control bar so
-    // they will adjust positioning when the control bar minimizes
-    if (mergeOptions.attachToControlBar &&
-        this.controlBar &&
-        mergeOptions.align.indexOf('bottom') !== -1) {
-      return this.controlBar.addChild('overlay', mergeOptions);
+    if (!this.controls() || !this.controlBar) {
+      return this.addChild('overlay', mergeOptions);
     }
 
-    return this.addChild('overlay', mergeOptions);
+    if (mergeOptions.attachToControlBar && mergeOptions.align.indexOf('bottom') !== -1) {
+      const referenceChild = this.controlBar.getChild(mergeOptions.insertBefore) || this.controlBar.children()[0];
+
+      if (referenceChild) {
+        const controlBarChild = this.controlBar.addChild('overlay', mergeOptions);
+
+        this.controlBar.el().insertBefore(
+          controlBarChild.el(),
+          referenceChild.el()
+        );
+        return controlBarChild;
+      }
+    }
+
+    const playerChild = this.addChild('overlay', mergeOptions);
+
+    this.el().insertBefore(
+      playerChild.el(),
+      this.controlBar.el()
+    );
+    return playerChild;
   });
 };
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -665,12 +665,11 @@ QUnit.test('can deinitialize the plugin on reinitialization', function(assert) {
   );
 });
 
-QUnit.test('attach bottom overlay as first child when insertBefore is invalid', function(assert) {
+QUnit.test('attach bottom overlay as first child when attachToControlBar is invalid component', function(assert) {
   assert.expect(1);
 
   this.player.overlay({
-    insertBefore: 'InvalidComponent',
-    attachToControlBar: true,
+    attachToControlBar: 'InvalidComponent',
     overlays: [{
       start: 'start',
       align: 'bottom'
@@ -686,12 +685,11 @@ QUnit.test('attach bottom overlay as first child when insertBefore is invalid', 
   );
 });
 
-QUnit.test('attach top overlay as previous sibling when insertBefore is invalid', function(assert) {
+QUnit.test('attach top overlay as previous sibling when attachToControlBar is invalid component', function(assert) {
   assert.expect(1);
 
   this.player.overlay({
-    insertBefore: 'InvalidComponent',
-    attachToControlBar: true,
+    attachToControlBar: 'InvalidComponent',
     overlays: [{
       start: 'start',
       align: 'top'
@@ -743,8 +741,7 @@ QUnit.test('attach overlays when attachToControlBar is true', function(assert) {
   );
 
   this.player.overlay({
-    attachToControlBar: true,
-    insertBefore: 'RemainingTimeDisplay',
+    attachToControlBar: 'RemainingTimeDisplay',
     overlays: [{
       start: 'start',
       align: 'bottom'
@@ -756,12 +753,11 @@ QUnit.test('attach overlays when attachToControlBar is true', function(assert) {
   assert.equal(
     this.player.controlBar.$('.vjs-overlay.vjs-overlay-bottom'),
     this.player.controlBar.remainingTimeDisplay.el().previousSibling,
-    'bottom attaches as previous sibiling of custom insertBefore'
+    'bottom attaches as previous sibiling of attachToControlBar component'
   );
 
   this.player.overlay({
-    attachToControlBar: true,
-    insertBefore: 'RemainingTimeDisplay',
+    attachToControlBar: 'RemainingTimeDisplay',
     overlays: [{
       start: 'start',
       align: 'top'
@@ -773,7 +769,7 @@ QUnit.test('attach overlays when attachToControlBar is true', function(assert) {
   assert.equal(
     this.player.$('.vjs-overlay.vjs-overlay-top'),
     this.player.controlBar.el().previousSibling,
-    'top attaches as previous sibiling of controlBar when using custom insertBefore'
+    'top attaches as previous sibiling of controlBar when using attachToControlBar component'
   );
 });
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -28,6 +28,7 @@ QUnit.module('videojs-overlay', {
 
     this.fixture = document.getElementById('qunit-fixture');
     this.video = document.createElement('video');
+    this.video.controls = true;
     this.fixture.appendChild(this.video);
     this.player = videojs(this.video);
 
@@ -661,5 +662,152 @@ QUnit.test('can deinitialize the plugin on reinitialization', function(assert) {
   assert.ok(
     this.player.$('.vjs-overlay.vjs-overlay-top-left'),
     'new top-left overlay added'
+  );
+});
+
+QUnit.test('attach bottom overlay as first child when insertBefore is invalid', function(assert) {
+  assert.expect(1);
+
+  this.player.overlay({
+    insertBefore: 'InvalidComponent',
+    attachToControlBar: true,
+    overlays: [{
+      start: 'start',
+      align: 'bottom'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.controlBar.el().firstChild,
+    'bottom attaches as first child of controlBar'
+  );
+});
+
+QUnit.test('attach top overlay as previous sibling when insertBefore is invalid', function(assert) {
+  assert.expect(1);
+
+  this.player.overlay({
+    insertBefore: 'InvalidComponent',
+    attachToControlBar: true,
+    overlays: [{
+      start: 'start',
+      align: 'top'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-top'),
+    this.player.controlBar.el().previousSibling,
+    'top attaches as previous sibiling of controlBar'
+  );
+});
+
+QUnit.test('attach overlays when attachToControlBar is true', function(assert) {
+  assert.expect(4);
+
+  this.player.overlay({
+    attachToControlBar: true,
+    overlays: [{
+      start: 'start',
+      align: 'bottom'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.controlBar.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.controlBar.el().firstChild,
+    'bottom attaches as first child of control bar'
+  );
+
+  this.player.overlay({
+    attachToControlBar: true,
+    overlays: [{
+      start: 'start',
+      align: 'top'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-top'),
+    this.player.controlBar.el().previousSibling,
+    'top attaches as previous sibiling of controlBar'
+  );
+
+  this.player.overlay({
+    attachToControlBar: true,
+    insertBefore: 'RemainingTimeDisplay',
+    overlays: [{
+      start: 'start',
+      align: 'bottom'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.controlBar.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.controlBar.remainingTimeDisplay.el().previousSibling,
+    'bottom attaches as previous sibiling of custom insertBefore'
+  );
+
+  this.player.overlay({
+    attachToControlBar: true,
+    insertBefore: 'RemainingTimeDisplay',
+    overlays: [{
+      start: 'start',
+      align: 'top'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-top'),
+    this.player.controlBar.el().previousSibling,
+    'top attaches as previous sibiling of controlBar when using custom insertBefore'
+  );
+});
+
+QUnit.test('attach overlays as last child when no controls are present', function(assert) {
+  assert.expect(2);
+  this.player.controls(false);
+
+  this.player.overlay({
+    overlays: [{
+      start: 'start',
+      align: 'bottom'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.el().lastChild,
+    'bottom attaches as last child of player'
+  );
+
+  this.player.overlay({
+    overlays: [{
+      start: 'start',
+      align: 'top'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-top'),
+    this.player.el().lastChild,
+    'top attaches as last child of player'
   );
 });


### PR DESCRIPTION
Summary:
Choose where the overlay element(s) should be placed when attached to the control bar.

Issue:
The current overlay placement does not allow user interaction with menu items when an overlay is present in the same display area as the menu. 

Use case example:
You want to attach an overlay to the bottom right hand side, and have captions present.

Proposed solution:
If attachToControlBar is true, and overlays are configured with an align of "bottom", "bottom-left", or "bottom-right", attach the overlays to either the insertBefore component, or as the first child of the control bar. Otherwise, attach the overlays before the control bar. If no controls are present, attach the overlays as a child of the player.