### PR TITLE
fix: plugin version

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,6 @@
 import videojs from 'video.js';
 import window from 'global/window';
+import {version as VERSION} from '../package.json';
 
 const defaults = {
   align: 'top-left',
@@ -355,7 +356,7 @@ const plugin = function(options) {
   });
 };
 
-plugin.VERSION = '__VERSION__';
+plugin.VERSION = VERSION;
 
 registerPlugin('overlay', plugin);
 


### PR DESCRIPTION
A few generator versions ago we used to find-replace `__VERSION__` with the package version, but we no longer do that.